### PR TITLE
Remove unused left sidebar config

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -110,9 +110,6 @@ html_favicon = '_static/favicon.ico'
 
 # -- HTML theme options
 # https://pydata-sphinx-theme.readthedocs.io/en/stable/user_guide/layout.html
-html_sidebars = {
-  "open_educational_resources": []
-}
 
 html_theme_options = {
     "navbar_start": ["navbar-logo"],


### PR DESCRIPTION
Including it in the config file causes the left sidebar to not be populated automatically.

